### PR TITLE
lsの機能拡張

### DIFF
--- a/public/javascripts/command.js
+++ b/public/javascripts/command.js
@@ -416,8 +416,15 @@ function exit(output_) {
     }
 }
 
-//aouthor shimada
-function ls(output_, cmdLine_, path) {
+//author shimada, tominaga
+function ls(output_, cmdLine_, path, target, root) {
+	var ret = existsTargetPath(path, target, root);
+	if (ret === null) {
+	    output_.insertAdjacentHTML('beforeEnd', '<div>No such file or directory</div>');
+	    return;
+	}
+	path = ret;
+
     if (!path.hasOwnProperty('shops')) {
         let iterable = Object.values(Object.values(path));
         var entries = [];
@@ -467,6 +474,40 @@ function ls(output_, cmdLine_, path) {
         output_.insertAdjacentHTML('beforeEnd', html);
         output_.scrollIntoView();
         cmdLine_.scrollIntoView();
+    }
+    
+    function existsTargetPath(curr, target, root) {
+    	if (target === undefined) { // target means a current directory
+    		return curr;
+    	}
+    
+    	var tmpTarget = " " + target;
+    	var currDir = (tmpTarget.indexOf(" /") !== -1) ? root : curr;
+    	
+    	var targetPaths = target.split("/");
+    	for (var i = 0; i < targetPaths.length; i++) {
+    		if (targetPaths[i] === "") {
+    			continue;
+    		}
+    	
+    		var found = false;
+    		var tmpDir = currDir;
+    		
+	    	Object.keys(currDir).forEach(function(key) {
+    			if (targetPaths[i] === this[key].name) {
+    				found = true;
+    				tmpDir = this[key];
+    			}
+    		}, currDir);
+    		
+    		if (found) {
+    			currDir = tmpDir;
+    		} else {
+    			return null;
+    		}
+    	}
+    	
+    	return currDir;
     }
 }
 
@@ -525,6 +566,7 @@ function cd(path, targetPath, dir, output_) {
         return goal;
     }
 
+	/*
     function findTargetDir(currDir, targetDir) {
         var found = false;
 
@@ -536,6 +578,7 @@ function cd(path, targetPath, dir, output_) {
 
         return found;
     }
+    */
 }
 
 function open1(output_, cmdLine_, args_all, current_path, callback) {

--- a/public/javascripts/runcommand.js
+++ b/public/javascripts/runcommand.js
@@ -153,11 +153,12 @@ function runCommand(e, node, output_, cmdLine_, CMDS_, dir, path) {
                 }
                 break;
             case 'ls':
-                if (argslen == 1) {
-                    ls(output_, cmdLine_, path.position);
+                /*if (argslen == 1) {
+                    ls(output_, cmdLine_, path.position, dir);
                 } else {
                     output('illegal input');
-                }
+                }*/
+                ls(output_, cmdLine_, path.position, args_first, dir.root);
                 break;
             case 'cd':
             	cd(path, args_first, dir, output_);

--- a/public/javascripts/runcommand.js
+++ b/public/javascripts/runcommand.js
@@ -34,6 +34,7 @@ function runCommand(e, node, output_, cmdLine_, CMDS_, dir, path) {
 		if (args_first !== undefined) {
 	        var tmpArgs = args_first.split("/");
 	        var isAbsolutePath = false;
+	        var addCurrentPath = false;
 
 	        if (tmpArgs[0] === "") { // starts with "/"
 	        	isAbsolutePath = true;
@@ -49,6 +50,7 @@ function runCommand(e, node, output_, cmdLine_, CMDS_, dir, path) {
 	      		} else if (tmpArgs[i] === "..") {
 	      			tmpArgs.splice(i, 1); // remove ".."
 	   				if (i === 0) {
+	   					addCurrentPath = true;
    		 		 		var tmpArray = path.string.split("/");
    		 		 		for (var k = 0; k < tmpArray.length - 1; k++) { // assume that path.string doesn't end with "/"
 	 			 			tmpArgs.splice(i++ , 0, tmpArray[k]);
@@ -71,7 +73,7 @@ function runCommand(e, node, output_, cmdLine_, CMDS_, dir, path) {
    				tmp += tmpArgs[j];
 			}
 			if (tmp === "") {
-				if (isAbsolutePath) {
+				if (isAbsolutePath || addCurrentPath) {
 					tmp = "/";
 				} else {
 					tmp = path.string;
@@ -79,6 +81,7 @@ function runCommand(e, node, output_, cmdLine_, CMDS_, dir, path) {
 			}
 			args_first = tmp;
 		}
+		console.log("args: " + args_first);
 
         output_.appendChild(pressEnterKey(node));
         //console.log(before);


### PR DESCRIPTION
lsに引数を与えて実行できるようにしました．
例えば/Osakaにいる状態で"ls OsakashiKitaku/Doujima"で堂島区域の店名一覧が出ます．
但し，店とディレクトリの区別や店名のスペース処理などをしてないのでlsの引数に具体的な店名を与えても"No such file or directory"と返されます．

ついでに".."の置き換えにバグを発見したので修正しました．
具体的には".."でルートかそれ以上上の階層まで遡ったとき，結果をルートではなくカレントディレクトリとして
扱ってしまうというものです．
